### PR TITLE
Improve animal ancestry chart layout

### DIFF
--- a/modules/asset/animal_ancestry/js/ancestry_tree.js
+++ b/modules/asset/animal_ancestry/js/ancestry_tree.js
@@ -11,14 +11,14 @@
         return;
       }
 
-      const width = 600;
-      const dx = 10;
-      const dy = 180;
+      const dx = 60;
+      const dy = 120;
       const tree = d3.tree().nodeSize([dx, dy]);
-      const diagonal = d3.linkHorizontal().x(d => d.y).y(d => d.x);
-
       const root = d3.hierarchy(data);
       tree(root);
+
+      // Invert the tree so ancestors appear above the selected asset.
+      root.each(d => d.y = -d.depth * dy);
 
       let x0 = Infinity;
       let x1 = -x0;
@@ -27,21 +27,21 @@
         if (d.x < x0) x0 = d.x;
       });
 
+      const height = root.height * dy + dx * 2;
       const svg = d3.select(container).append('svg')
-        .attr('viewBox', [0, 0, width, x1 - x0 + dx * 2]);
+        .attr('viewBox', [x0 - dx, -height, x1 - x0 + dx * 2, height]);
 
       const g = svg.append('g')
-        .attr('transform', `translate(${dy / 3},${dx - x0})`);
+        .attr('transform', `translate(0, ${height - dx})`);
 
       g.append('g')
         .attr('fill', 'none')
-        .attr('stroke', '#555')
-        .attr('stroke-opacity', 0.4)
+        .attr('stroke', '#000')
         .attr('stroke-width', 1.5)
         .selectAll('path')
         .data(root.links())
         .join('path')
-        .attr('d', diagonal);
+        .attr('d', d => `M${d.source.x},${d.source.y}V${d.target.y}H${d.target.x}`);
 
       const node = g.append('g')
         .attr('stroke-linejoin', 'round')
@@ -49,18 +49,18 @@
         .selectAll('g')
         .data(root.descendants())
         .join('g')
-        .attr('transform', d => `translate(${d.y},${d.x})`);
+        .attr('transform', d => `translate(${d.x},${d.y})`);
 
       node.append('circle')
-        .attr('fill', d => d.children ? '#555' : '#999')
+        .attr('fill', d => d.data.selected ? '#f00' : d.children ? '#555' : '#999')
         .attr('r', 4);
 
       node.append('a')
         .attr('xlink:href', d => d.data.url)
         .append('text')
         .attr('dy', '0.31em')
-        .attr('x', d => d.children ? -6 : 6)
-        .attr('text-anchor', d => d.children ? 'end' : 'start')
+        .attr('x', 6)
+        .attr('text-anchor', 'start')
         .text(d => d.data.name)
         .clone(true).lower()
         .attr('stroke', 'white');

--- a/modules/asset/animal_ancestry/src/Controller/AncestryController.php
+++ b/modules/asset/animal_ancestry/src/Controller/AncestryController.php
@@ -31,7 +31,7 @@ class AncestryController extends ControllerBase {
         'library' => ['farm_animal_ancestry/tree'],
         'drupalSettings' => [
           'farmAnimalAncestry' => [
-            'tree' => $this->buildTreeData($asset),
+            'tree' => $this->buildTreeData($asset, $asset->id()),
           ],
         ],
       ],
@@ -41,17 +41,19 @@ class AncestryController extends ControllerBase {
   /**
    * Recursively build ancestry data for the JavaScript tree.
    */
-  protected function buildTreeData(AssetInterface $asset): array {
+  protected function buildTreeData(AssetInterface $asset, ?int $selected_id = NULL): array {
+    $selected_id = $selected_id ?? $asset->id();
     $node = [
       'name' => $asset->label(),
       'url' => $asset->toUrl()->toString(),
+      'selected' => $asset->id() === $selected_id,
       'children' => [],
     ];
     foreach (['mother', 'father'] as $role) {
       /** @var \Drupal\asset\Entity\AssetInterface|null $parent */
       $parent = $asset->get($role)->entity;
       if ($parent) {
-        $node['children'][] = $this->buildTreeData($parent);
+        $node['children'][] = $this->buildTreeData($parent, $selected_id);
       }
     }
     return $node;


### PR DESCRIPTION
## Summary
- highlight selected asset on ancestry chart
- flip chart vertically with straight black lines for cleaner ancestry view

## Testing
- `npm test` *(fails: Could not read package.json)*
- `composer test` *(fails: Command "test" is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68acd44315208330b9bde065d6bff673