### PR TITLE
Force single-value animal parent references

### DIFF
--- a/modules/asset/animal/farm_animal.install
+++ b/modules/asset/animal/farm_animal.install
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Remove extra mother and father field values stored before cardinality fix.
+ */
+function farm_animal_update_9001(): void {
+  $tables = [
+    'asset__mother',
+    'asset_revision__mother',
+    'asset__father',
+    'asset_revision__father',
+  ];
+  $database = \Drupal::database();
+  foreach ($tables as $table) {
+    if ($database->schema()->tableExists($table)) {
+      $database->delete($table)
+        ->condition('delta', 0, '>')
+        ->execute();
+    }
+  }
+}

--- a/modules/asset/animal/farm_animal.module
+++ b/modules/asset/animal/farm_animal.module
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+use Drupal\Core\Entity\EntityInterface;
+
+/**
+ * Implements hook_entity_presave().
+ */
+function farm_animal_entity_presave(EntityInterface $entity): void {
+  if ($entity->getEntityTypeId() !== 'asset' || $entity->bundle() !== 'animal') {
+    return;
+  }
+  if (!$entity->get('mother')->isEmpty()) {
+    $entity->set('mother', $entity->get('mother')->first());
+  }
+  if (!$entity->get('father')->isEmpty()) {
+    $entity->set('father', $entity->get('father')->first());
+  }
+}

--- a/modules/asset/animal/modules/ancestry/farm_animal_ancestry.info.yml
+++ b/modules/asset/animal/modules/ancestry/farm_animal_ancestry.info.yml
@@ -1,0 +1,7 @@
+name: Animal ancestry chart
+description: Displays an ancestry chart for animal assets.
+type: module
+package: farmOS Animal
+core_version_requirement: ^10
+dependencies:
+  - farm:farm_animal

--- a/modules/asset/animal/modules/ancestry/farm_animal_ancestry.libraries.yml
+++ b/modules/asset/animal/modules/ancestry/farm_animal_ancestry.libraries.yml
@@ -1,0 +1,7 @@
+tree:
+  js:
+    https://cdn.jsdelivr.net/npm/d3@7/dist/d3.min.js: { type: external, minified: true, crossorigin: anonymous }
+    js/ancestry_tree.js: {}
+  dependencies:
+    - core/drupal
+    - core/drupalSettings

--- a/modules/asset/animal/modules/ancestry/farm_animal_ancestry.links.task.yml
+++ b/modules/asset/animal/modules/ancestry/farm_animal_ancestry.links.task.yml
@@ -1,0 +1,5 @@
+farm.asset.ancestry:
+  route_name: farm.asset.ancestry
+  title: 'Ancestry'
+  base_route: entity.asset.canonical
+  weight: 120

--- a/modules/asset/animal/modules/ancestry/farm_animal_ancestry.module
+++ b/modules/asset/animal/modules/ancestry/farm_animal_ancestry.module
@@ -1,0 +1,8 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @file
+ * Provides ancestry chart for animal assets.
+ */

--- a/modules/asset/animal/modules/ancestry/farm_animal_ancestry.routing.yml
+++ b/modules/asset/animal/modules/ancestry/farm_animal_ancestry.routing.yml
@@ -1,0 +1,13 @@
+farm.asset.ancestry:
+  path: '/asset/{asset}/ancestry'
+  defaults:
+    _title: 'Ancestry'
+    _controller: '\Drupal\farm_animal_ancestry\Controller\AncestryController::chart'
+  requirements:
+    _custom_access: '\Drupal\farm_animal_ancestry\Controller\AncestryController::access'
+    _module_dependencies: 'asset'
+    asset: '\d+'
+  options:
+    parameters:
+      asset:
+        type: entity:asset

--- a/modules/asset/animal/modules/ancestry/js/ancestry_tree.js
+++ b/modules/asset/animal/modules/ancestry/js/ancestry_tree.js
@@ -1,0 +1,69 @@
+(function (Drupal, drupalSettings) {
+  Drupal.behaviors.farmAnimalAncestryTree = {
+    attach: function (context, settings) {
+      const container = context.querySelector('#animal-ancestry-chart');
+      if (!container || container.dataset.processed) {
+        return;
+      }
+      container.dataset.processed = true;
+      const data = drupalSettings.farmAnimalAncestry && drupalSettings.farmAnimalAncestry.tree;
+      if (!data) {
+        return;
+      }
+
+      const dx = 60;
+      const dy = 120;
+      const tree = d3.tree().nodeSize([dx, dy]);
+      const root = d3.hierarchy(data);
+      tree(root);
+
+      // Invert the tree so ancestors appear above the selected asset.
+      root.each(d => d.y = -d.depth * dy);
+
+      let x0 = Infinity;
+      let x1 = -x0;
+      root.each(d => {
+        if (d.x > x1) x1 = d.x;
+        if (d.x < x0) x0 = d.x;
+      });
+
+      const height = root.height * dy + dx * 2;
+      const svg = d3.select(container).append('svg')
+        .attr('viewBox', [x0 - dx, -height, x1 - x0 + dx * 2, height]);
+
+      const g = svg.append('g')
+        .attr('transform', `translate(0, ${height - dx})`);
+
+      g.append('g')
+        .attr('fill', 'none')
+        .attr('stroke', '#000')
+        .attr('stroke-width', 1.5)
+        .selectAll('path')
+        .data(root.links())
+        .join('path')
+        .attr('d', d => `M${d.source.x},${d.source.y}V${d.target.y}H${d.target.x}`);
+
+      const node = g.append('g')
+        .attr('stroke-linejoin', 'round')
+        .attr('stroke-width', 3)
+        .selectAll('g')
+        .data(root.descendants())
+        .join('g')
+        .attr('transform', d => `translate(${d.x},${d.y})`);
+
+      node.append('circle')
+        .attr('fill', d => d.data.selected ? '#f00' : d.children ? '#555' : '#999')
+        .attr('r', 4);
+
+      node.append('a')
+        .attr('xlink:href', d => d.data.url)
+        .append('text')
+        .attr('dy', '0.31em')
+        .attr('x', 6)
+        .attr('text-anchor', 'start')
+        .text(d => d.data.name)
+        .clone(true).lower()
+        .attr('stroke', 'white');
+    }
+  };
+})(Drupal, drupalSettings);

--- a/modules/asset/animal/modules/ancestry/src/Controller/AncestryController.php
+++ b/modules/asset/animal/modules/ancestry/src/Controller/AncestryController.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\farm_animal_ancestry\Controller;
+
+use Drupal\Core\Access\AccessResult;
+use Drupal\Core\Controller\ControllerBase;
+use Drupal\asset\Entity\AssetInterface;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+/**
+ * Controller for animal ancestry charts.
+ */
+class AncestryController extends ControllerBase {
+
+  /**
+   * Display an ancestry chart for the provided animal asset.
+   */
+  public function chart(AssetInterface $asset) {
+    if ($asset->bundle() !== 'animal') {
+      throw new NotFoundHttpException();
+    }
+    return [
+      '#title' => $this->t('Ancestry for @name', ['@name' => $asset->label()]),
+      'chart' => [
+        '#type' => 'container',
+        '#attributes' => ['id' => 'animal-ancestry-chart'],
+      ],
+      '#attached' => [
+        'library' => ['farm_animal_ancestry/tree'],
+        'drupalSettings' => [
+          'farmAnimalAncestry' => [
+            'tree' => $this->buildTreeData($asset, $asset->id()),
+          ],
+        ],
+      ],
+    ];
+  }
+
+  /**
+   * Recursively build ancestry data for the JavaScript tree.
+   */
+  protected function buildTreeData(AssetInterface $asset, int|string|null $selected_id = NULL): array {
+    $selected_id = (string) ($selected_id ?? $asset->id());
+    $node = [
+      'name' => $asset->label(),
+      'url' => $asset->toUrl()->toString(),
+      'selected' => (string) $asset->id() === $selected_id,
+      'children' => [],
+    ];
+    foreach (['mother', 'father'] as $role) {
+      /** @var \Drupal\asset\Entity\AssetInterface|null $parent */
+      $parent = $asset->get($role)->entity;
+      if ($parent) {
+        $node['children'][] = $this->buildTreeData($parent, $selected_id);
+      }
+    }
+    return $node;
+  }
+
+  /**
+   * Access callback to limit route to animal assets.
+   */
+  public function access(AssetInterface $asset): AccessResult {
+    return AccessResult::allowedIf($asset->bundle() === 'animal')->addCacheableDependency($asset);
+  }
+
+}
+

--- a/modules/asset/animal/src/Plugin/Asset/AssetType/Animal.php
+++ b/modules/asset/animal/src/Plugin/Asset/AssetType/Animal.php
@@ -85,6 +85,30 @@ class Animal extends FarmAssetType {
           'view' => -30,
         ],
       ],
+      'mother' => [
+        'type' => 'entity_reference',
+        'label' => $this->t('Mother'),
+        'description' => $this->t('Reference the mother of this animal.'),
+        'target_type' => 'asset',
+        'target_bundle' => 'animal',
+        'cardinality' => 1,
+        'weight' => [
+          'form' => 25,
+          'view' => -20,
+        ],
+      ],
+      'father' => [
+        'type' => 'entity_reference',
+        'label' => $this->t('Father'),
+        'description' => $this->t('Reference the father of this animal.'),
+        'target_type' => 'asset',
+        'target_bundle' => 'animal',
+        'cardinality' => 1,
+        'weight' => [
+          'form' => 26,
+          'view' => -15,
+        ],
+      ],
     ];
     foreach ($field_info as $name => $info) {
       $fields[$name] = $this->farmFieldFactory->bundleFieldDefinition($info);


### PR DESCRIPTION
## Summary
- mark animal mother and father fields as single-value references
- enforce single-value storage on save
- clean up pre-existing extra parent rows
- add animal ancestry chart module that visualizes parentage

## Testing
- `vendor/bin/phpunit -c core/phpunit.xml.dist modules/quick/birth/tests/src/Kernel/QuickBirthTest.php` *(fails: vendor/bin/phpunit: No such file or directory)*
- `php -l modules/asset/animal/src/Plugin/Asset/AssetType/Animal.php`
- `php -l modules/asset/animal/farm_animal.module`
- `php -l modules/asset/animal/farm_animal.install`
- `php -l modules/asset/animal/modules/ancestry/src/Controller/AncestryController.php`
- `php -l modules/asset/animal/modules/ancestry/farm_animal_ancestry.module`


------
https://chatgpt.com/codex/tasks/task_e_68acb4db1768833087a9381dd19b9e60